### PR TITLE
Add Hook dependency getter

### DIFF
--- a/src/Servers/Hook.php
+++ b/src/Servers/Hook.php
@@ -168,6 +168,26 @@ class Hook
     }
 
     /**
+     * Get Dependencies
+     *
+     * @return array
+     */
+    public function getDependencies(): array
+    {
+        if (empty($this->injections)) {
+            return [];
+        }
+
+        $injections = array_values($this->injections);
+
+        usort($injections, static function (array $left, array $right): int {
+            return $left['order'] <=> $right['order'];
+        });
+
+        return array_column($injections, 'name');
+    }
+
+    /**
      * Inject
      *
      * @param  string  $injection

--- a/tests/Servers/Unit/HookTest.php
+++ b/tests/Servers/Unit/HookTest.php
@@ -73,6 +73,19 @@ class HookTest extends TestCase
         $this->assertEquals('time', $this->hook->getInjections()['time']['name']);
     }
 
+    public function testDependenciesAreReturnedInInjectionOrder()
+    {
+        $this->assertEquals([], $this->hook->getDependencies());
+
+        $this->hook
+            ->inject('user')
+            ->param('x', '', new Text(10))
+            ->inject('time')
+            ->inject('locale');
+
+        $this->assertEquals(['user', 'time', 'locale'], $this->hook->getDependencies());
+    }
+
     public function testParamValuesCanBeSet()
     {
         $this->assertEquals([], $this->hook->getParams());


### PR DESCRIPTION
## Summary
- add Hook::getDependencies to return injection names in order
- add unit test covering dependency order

## Testing
- not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to retrieve dependencies in their established injection order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->