### PR TITLE
Add enum metadata to hook params

### DIFF
--- a/src/Servers/Hook.php
+++ b/src/Servers/Hook.php
@@ -223,9 +223,10 @@ class Hook
      * @param string $example
      * @param string|null $model
      * @param array $aliases
+     * @param object|null $enum
      * @return static
      */
-    public function param(string $key, mixed $default, Validator|callable $validator, string $description = '', bool $optional = false, array $injections = [], bool $skipValidation = false, bool $deprecated = false, string $example = '', ?string $model = null, array $aliases = []): static
+    public function param(string $key, mixed $default, Validator|callable $validator, string $description = '', bool $optional = false, array $injections = [], bool $skipValidation = false, bool $deprecated = false, string $example = '', ?string $model = null, array $aliases = [], ?object $enum = null): static
     {
         $this->params[$key] = [
             'default' => $default,
@@ -238,6 +239,7 @@ class Hook
             'example' => $example,
             'model' => $model,
             'aliases' => $aliases,
+            'enum' => $enum,
             'value' => null,
             'order' => count($this->params) + count($this->injections),
         ];

--- a/tests/Servers/Unit/HookTest.php
+++ b/tests/Servers/Unit/HookTest.php
@@ -81,6 +81,25 @@ class HookTest extends TestCase
         $this->assertSame(['project', 'project_id'], $params['projectId']['aliases']);
     }
 
+    public function testParamEnumCanBeSet()
+    {
+        $enum = new \stdClass();
+        $enum->name = 'ArticleStatus';
+        $enum->map = ['draft' => 'Draft', 'published' => 'Published'];
+
+        $this->hook->param(
+            'status',
+            'draft',
+            new Text(32),
+            description: 'Status.',
+            optional: true,
+            enum: $enum
+        );
+
+        $params = $this->hook->getParams();
+        $this->assertSame($enum, $params['status']['enum']);
+    }
+
     public function testResourcesCanBeInjected()
     {
         $this->assertEquals([], $this->hook->getInjections());


### PR DESCRIPTION
## Summary
- add optional enum metadata to Hook::param()
- store enum metadata with hook params for downstream route/platform usage
- add unit coverage for enum metadata

## Tests
- vendor/bin/phpunit
- php -d error_reporting=22527 vendor/bin/pint --test src/Servers/Hook.php tests/Servers/Unit/HookTest.php